### PR TITLE
Minor improvements: naming convention & HF model cards

### DIFF
--- a/acip/core/README_template.md
+++ b/acip/core/README_template.md
@@ -1,12 +1,9 @@
 ---
 license: {{LICENSE}}
-datasets:
-- allenai/c4
-language:
-- en
-metrics:
-- perplexity
-- accuracy
+datasets: {{DATASETS}}
+language: {{LANGUAGE}}
+metrics: {{METRICS}}
+tags: {{TAGS}}
 base_model:
 - {{BASE_MODEL}}
 pipeline_tag: text-generation

--- a/acip/core/README_template.md
+++ b/acip/core/README_template.md
@@ -45,10 +45,10 @@ from transformers import AutoModel
 
 model = AutoModel.from_pretrained("{{REPO_ID}}", trust_remote_code=True)
 ```
-This will download and create a fully parameterized ACIP model that can be pruned to any compression ratio you wish.
+This will download and create a fully parameterized ACIP model that can be pruned to any compression rate you wish.
 For example,
 ```python
-model.prune_model_by_score(compression_ratio=0.4)
+model.prune_model_by_score(size_ratio=0.4)
 ```
 will prune `model` to 40% if its original size measured in number of parameters, i.e., 60% compression rate.
 A unique feature of ACIP is that this operation is revertible in the sense that you can rerun `model.prune_model_by_score` as often as you like to evaluate your model at different sizes. Finally, you can "commit" to a certain ratio and run
@@ -65,7 +65,7 @@ to save even more memory (we have only tested 4bit quantization with `bitsandbyt
 
 **🚀 That's it! You can now use your compressed model for inference or fine-tuning as any other Causal Language Model from 🤗 transformers.**
 
-**Note**: The parameter `compression_ratio` ranges from 1.0 to 0.0, indicating the model size after compression. For example, 0.4 means that the model has only 40% of the original number of parameters and 1.0 means no compression at all.
+**Note**: The parameter `size_ratio` ranges from 1.0 to 0.0, indicating the model size after compression. For example, 0.4 means that the model has only 40% of the original number of parameters and 1.0 means no compression at all. Alternatively, you can also set `compression_rate` in `prune_model_by_score`, which is equivalent to `size_ratio = 1.0 - compression_rate`.
 
 # Dependencies
 

--- a/acip/core/parametrized_model.py
+++ b/acip/core/parametrized_model.py
@@ -353,7 +353,7 @@ class ParametrizedModel(PreTrainedModel):
     The corresponding modules are accessed via `parametrized_modules`, `adapter_modules`,
     and `quantized_modules`, respectively.
     The class also provides several convenience methods to manage the parametrization: `get_target_params`,
-    `get_num_params`, `get_compression_ratio`, `reset_target_params`, `compress`.
+    `get_num_params`, `get_size_ratio`, `reset_target_params`, `compress`.
 
     Standard functionality (`forward`, `generate`, `save_pretrained`, `from_pretrained`) is essentially forwarded
     to the wrapped model.
@@ -698,9 +698,9 @@ class ParametrizedModel(PreTrainedModel):
             num_params = 1e-6
         return num_params
 
-    def get_compression_ratio(self, full: bool = False, target_params: dict[str, torch.Tensor] | None = None) -> float:
+    def get_size_ratio(self, full: bool = False, target_params: dict[str, torch.Tensor] | None = None) -> float:
         """
-        Convenience function to compute the compression ratio of the present model.
+        Convenience function to compute the size ratio of the present model.
 
         See Also:
             `get_num_params`

--- a/acip/entrypoints/acip_push_to_hub.py
+++ b/acip/entrypoints/acip_push_to_hub.py
@@ -68,13 +68,17 @@ def main(cfg: DictConfig) -> None:
     # Upload all additional files
     parent_dir = os.path.join(PROJECT_ROOT, "acip", "core")
 
-    # Render temporary README and fill in templates
+    # Render temporary model card (README) and fill in templates
     with open(os.path.join(parent_dir, "README_template.md"), "r") as f:
         readme = f.read()
     readme = readme.replace("{{BASE_MODEL}}", cfg.model.base_model_name_or_path)
     readme = readme.replace("{{REPO_ID}}", cfg.acip.hub.repo_id)
     readme = readme.replace("{{LICENSE}}", cfg.acip.hub.license)
     readme = readme.replace("{{LICENSE_TEXT}}", cfg.acip.hub.license_text)
+    readme = readme.replace("{{METRICS}}", str(cfg.acip.hub.metrics))
+    readme = readme.replace("{{LANGUAGE}}", str(cfg.acip.hub.language))
+    readme = readme.replace("{{DATASETS}}", str(cfg.acip.hub.datasets))
+    readme = readme.replace("{{TAGS}}", str(cfg.acip.hub.tags))
     with open(os.path.join(parent_dir, "README.md"), "w") as f:
         f.write(readme)
 

--- a/acip/model/model_factory.py
+++ b/acip/model/model_factory.py
@@ -91,7 +91,7 @@ class ACIPModelFactory(PretrainedModelFactory):
             pretrained_model_config: Optional config passed to `from_pretrained` or the model constructor.
             pretrained_model_kwargs: Keyword arguments passed to `from_pretrained` or the model constructor.
             prune_to_ratio: If a float between 0 and 1 is provided, the created model will be directly pruned
-                according to this compression ratio. See `ACIPModel.prune_model_by_score`.
+                according to this size ratio. See `ACIPModel.prune_model_by_score`.
             compress_and_unparametrize: If True, the parametrized modules of the created model will compressed
                 according to their pruning state (controlled by `prune_to_ratio`) and non-compressible modules
                 will be unparametrized. See `ParametrizedModel.compress`. Note that compared to `prune_to_ratio`,
@@ -115,9 +115,9 @@ class ACIPModelFactory(PretrainedModelFactory):
         assert isinstance(model, ACIPModel), "Model must be of type ACIPModel"
 
         if self.prune_to_ratio is not None:
-            # Prune target params to desired compression ratio ...
-            model.prune_model_by_score(compression_ratio=self.prune_to_ratio, full=self.measure_ratio_full)
-            logger.info(f"Pruned model to compression ratio {self.prune_to_ratio}.")
+            # Prune target params to desired size ratio ...
+            model.prune_model_by_score(size_ratio=self.prune_to_ratio, full=self.measure_ratio_full)
+            logger.info(f"Pruned model to size ratio {self.prune_to_ratio}.")
 
             # ... and compress.
             if self.compress_and_unparametrize:

--- a/acip/training/benchmarking.py
+++ b/acip/training/benchmarking.py
@@ -32,7 +32,7 @@ class ModelBenchmarker(pl.Callback):
         Args:
             evaluator: `ModelEvaluator` instance to use for benchmarking.
             test_ratios: If a list of floats between 0 and 1 is provided, the model will be pruned to each of these
-                compression ratios (via `ACIPModel.prune_model_by_score`) and evaluated.
+                size ratios (via `ACIPModel.prune_model_by_score`) and evaluated.
                 If `None`, the model will be evaluated at the end of training as it is.
             measure_ratio_full: If `True`, all parameters of the model are counted when pruning to a target ratio
                 is performed, if `False` only the parameters of the parametrized modules are counted (default).
@@ -63,13 +63,13 @@ class ModelBenchmarker(pl.Callback):
         if self.test_ratios is not None:
             # This only works for `ACIPModel`s
             assert isinstance(pl_module.model, ACIPModel)
-            # Benchmark model at each compression ratio
+            # Benchmark model at each size ratio
             for ratio in self.test_ratios:
-                logger.info(f"Benchmarking model at compression ratio {ratio}.")
-                pl_module.model.prune_model_by_score(compression_ratio=ratio, full=self.measure_ratio_full)
+                logger.info(f"Benchmarking model at size ratio {ratio}.")
+                pl_module.model.prune_model_by_score(size_ratio=ratio, full=self.measure_ratio_full)
                 self.results[f"at_end_ratio{ratio}"] = self.evaluator(model=pl_module.model)
-                # Add target compression ratio to results for better identification
-                self.results[f"at_end_ratio{ratio}"]["target_compression_ratio"] = ratio
+                # Add target size ratio to results for better identification
+                self.results[f"at_end_ratio{ratio}"]["target_size_ratio"] = ratio
 
                 if wandb.run is not None:
                     fig = generate_params_plot(pl_module.model.get_target_params(), zmin=None, zmax=None)

--- a/acip/training/monitoring.py
+++ b/acip/training/monitoring.py
@@ -130,13 +130,13 @@ class ACIPEfficiencyMonitor(pl.Callback):
      - peak_memory_reserved: The peak memory reserved by the model in GB.
     """
 
-    def __init__(self, min_compression_ratio: float = 0.4):
+    def __init__(self, min_size_ratio: float = 0.4):
         """
         Args:
-            min_compression_ratio: Minimum compression ratio that pruning will be tested with.
+            min_size_ratio: Minimum size ratio that pruning will be tested with.
         """
         super().__init__()
-        self.min_compression_ratio = min_compression_ratio
+        self.min_size_ratio = min_size_ratio
 
         # Stores the monitored results
         self.results: dict[str, Any] = {}
@@ -166,12 +166,12 @@ class ACIPEfficiencyMonitor(pl.Callback):
         self.results["pruning_time"] = time.time()
         num_tests = 20
         for _ in tqdm(range(num_tests), desc="Measuring pruning time"):
-            compression_ratio = np.random.uniform(self.min_compression_ratio, 1.0)
-            pl_module.model.prune_model_by_score(compression_ratio=compression_ratio)
+            size_ratio = np.random.uniform(self.min_size_ratio, 1.0)
+            pl_module.model.prune_model_by_score(size_ratio=size_ratio)
         self.results["pruning_time"] = (time.time() - self.results["pruning_time"]) / num_tests
 
         # Measure time of actual compression
-        pl_module.model.prune_model_by_score(compression_ratio=self.min_compression_ratio)
+        pl_module.model.prune_model_by_score(size_ratio=self.min_size_ratio)
         self.results["compress_time"] = time.time()
         pl_module.model.compress()
         self.results["compress_time"] = time.time() - self.results["compress_time"]

--- a/config/entrypoints/acip_compress.yaml
+++ b/config/entrypoints/acip_compress.yaml
@@ -49,7 +49,7 @@ run:
 acip:
   cache_init_model: false
   quantize_weights: false  # optionally quantize U and V weights of SVD parametrization
-  stop_ratio: 0.4  # compression ratio at which to stop ACIP (subsequent compression should not be lower)
+  stop_ratio: 0.4  # size ratio at which to stop ACIP (subsequent compression should not be lower)
   stop_score_map_at_ratio: # means that the score map update continues until the stopping criterion reached
   measure_ratio_full: false  # count all parameters while compressing (true) or just all parametrized modules (false)
   post_tune_steps: 1000  # how many steps to continue optimizing adapters after ACIP stopped
@@ -58,5 +58,5 @@ acip:
   reg_scheduler_update_every: 4
   reg_scheduler_update_factor: 1.01
   lr: 5e-5
-  # Compression ratios at which to evaluate the final model. None means the ACIP model is evaluated at it is.
+  # Size ratios at which to evaluate the final model. None means the ACIP model is evaluated at it is.
   test_ratios: [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]

--- a/config/entrypoints/acip_eval.yaml
+++ b/config/entrypoints/acip_eval.yaml
@@ -47,11 +47,11 @@ training:
 # Define ACIP-eval-specific config.
 acip:
   quantize_weights: false  # optionally quantize U and V weights of SVD parametrization
-  # Target compression ratio at which the model is materialized after loading.
+  # Target size ratio at which the model is materialized after loading.
   # If "test_ratios" is specified, this is ignored and you can leave it None.
   prune_to_ratio:
   measure_ratio_full: false  # count all parameters while compressing (true) or just all parametrized modules (false)
   compress_and_unparametrize: false  # whether to actually compress the model (cannot be reverted)
-  # Compression ratios at which to evaluate the final model. None means the ACIP model is evaluated at it is.
+  # Size ratios at which to evaluate the final model. None means the ACIP model is evaluated at it is.
   test_ratios: [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
   lr: 2e-4  # dummy (no tuning)

--- a/config/entrypoints/acip_finetune.yaml
+++ b/config/entrypoints/acip_finetune.yaml
@@ -56,7 +56,7 @@ training:
 # Define ACIP-finetune-specific config.
 acip:
   quantize_weights: false  # optionally quantize U and V weights of SVD parametrization
-  prune_to_ratio: 0.4  # target compression ratio at which the model is materialized before finetuning
+  prune_to_ratio: 0.4  # target size ratio at which the model is materialized before finetuning
   measure_ratio_full: false  # count all parameters while compressing (true) or just all parametrized modules (false)
   compress_and_unparametrize: true  # whether to actually compress the model (cannot be reverted)
   finetune_steps: 25000

--- a/config/entrypoints/acip_push_to_hub.yaml
+++ b/config/entrypoints/acip_push_to_hub.yaml
@@ -13,6 +13,8 @@ defaults:
   - /model/base@model: default  # it's important that base comes after tokenizer_factory because it may overwrite it
   # Load behavior of the ACIP model.
   - storage@acip: acip_push_to_hub
+  # Hub-related config.
+  - hub@acip: default
 
 paths:
   # Add the current run series to the parent run directory.
@@ -33,10 +35,3 @@ acip:
   prune_to_ratio:
   measure_ratio_full: false
   compress_and_unparametrize: false
-  # Hub-specific config.
-  hub:
-    push_model: true  # otherwise, only accompanying files are pushed
-    # Required for README rendering.
-    repo_id: MerantixMomentum/acip_${model.identifier}
-    license: apache-2.0
-    license_text: This model is released under the ${acip.hub.license} license.

--- a/config/entrypoints/hub/default.yaml
+++ b/config/entrypoints/hub/default.yaml
@@ -1,0 +1,18 @@
+# HuggingFace Hub-specific config used for in acip_push_to_hub entrypoint.
+
+hub:
+  push_model: true  # otherwise, only accompanying files are pushed
+  # Metadata for model card rendering (README).
+  repo_id: MerantixMomentum/acip_${model.identifier}
+  license: apache-2.0
+  license_text: This model is released under the ${acip.hub.license} license.
+  metrics:
+    - perplexity
+    - accuracy
+  language:
+    - en
+  datasets:
+    - allenai/c4
+  tags:
+    - acip
+    - pytorch

--- a/config/entrypoints/hub/llama1_13b.yaml
+++ b/config/entrypoints/hub/llama1_13b.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - default
+
+hub:
+  license: other
+  license_text: The license is inherited from the base model ${model.base_model_name_or_path}.

--- a/config/entrypoints/hub/llama1_7b.yaml
+++ b/config/entrypoints/hub/llama1_7b.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - default
+
+hub:
+  license: other
+  license_text: The license is inherited from the base model ${model.base_model_name_or_path}.

--- a/config/entrypoints/hub/llama2_13b.yaml
+++ b/config/entrypoints/hub/llama2_13b.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - default
+
+hub:
+  license: llama2

--- a/config/entrypoints/hub/llama2_7b.yaml
+++ b/config/entrypoints/hub/llama2_7b.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - default
+
+hub:
+  license: llama2

--- a/config/entrypoints/hub/llama31_8b.yaml
+++ b/config/entrypoints/hub/llama31_8b.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - default
+
+hub:
+  license: llama3.1
+  language:
+    - en
+    - de
+    - fr
+    - it
+    - pt
+    - hi
+    - es
+    - th

--- a/config/entrypoints/hub/mistral03_7b.yaml
+++ b/config/entrypoints/hub/mistral03_7b.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - default

--- a/config/entrypoints/hub/qwen25_14b.yaml
+++ b/config/entrypoints/hub/qwen25_14b.yaml
@@ -1,0 +1,18 @@
+defaults:
+  - default
+
+hub:
+  language:
+    - zho
+    - eng
+    - fra
+    - spa
+    - por
+    - deu
+    - ita
+    - rus
+    - jpn
+    - kor
+    - vie
+    - tha
+    - ara

--- a/config/entrypoints/hub/qwen25_3b.yaml
+++ b/config/entrypoints/hub/qwen25_3b.yaml
@@ -1,0 +1,18 @@
+defaults:
+  - default
+
+hub:
+  language:
+    - zho
+    - eng
+    - fra
+    - spa
+    - por
+    - deu
+    - ita
+    - rus
+    - jpn
+    - kor
+    - vie
+    - tha
+    - ara

--- a/config/entrypoints/hub/qwen25_7b.yaml
+++ b/config/entrypoints/hub/qwen25_7b.yaml
@@ -1,0 +1,18 @@
+defaults:
+  - default
+
+hub:
+  language:
+    - zho
+    - eng
+    - fra
+    - spa
+    - por
+    - deu
+    - ita
+    - rus
+    - jpn
+    - kor
+    - vie
+    - tha
+    - ara

--- a/config/experiment/paper/llama1_7b/ablation/compress_sweep_stop.yaml
+++ b/config/experiment/paper/llama1_7b/ablation/compress_sweep_stop.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 
-# Ablation experiment: Run ACIP for different stopping criteria, i.e., at which compression ratio to stop
+# Ablation experiment: Run ACIP for different stopping criteria, i.e., at which size ratio to stop
 # (0.2, 0.3, 0.4, 0.6, 0.8, 0.95).
 
 defaults:

--- a/config/training/monitoring/acip_efficiency_monitor.yaml
+++ b/config/training/monitoring/acip_efficiency_monitor.yaml
@@ -1,4 +1,4 @@
 callbacks:
   acip_efficiency_monitor:
     _target_: acip.training.monitoring.ACIPEfficiencyMonitor
-    min_compression_ratio: ${oc.select:acip.stop_ratio, 0.4}
+    min_size_ratio: ${oc.select:acip.stop_ratio, 0.4}

--- a/scripts/push_model_to_hub.sh
+++ b/scripts/push_model_to_hub.sh
@@ -1,11 +1,11 @@
 #!/bin/zsh
 
-python -m acip.entrypoints.acip_push_to_hub model/base@model=llama1_7b acip.hub.license=other acip.hub.license_text="The license is inherited from the base model jeffwan/llama-7b-hf."
-python -m acip.entrypoints.acip_push_to_hub model/base@model=llama1_13b acip.hub.license=other acip.hub.license_text="The license is inherited from the base model jeffwan/llama-13b-hf."
-python -m acip.entrypoints.acip_push_to_hub model/base@model=llama2_7b acip.hub.license=llama2
-python -m acip.entrypoints.acip_push_to_hub model/base@model=llama2_13b acip.hub.license=llama2
-python -m acip.entrypoints.acip_push_to_hub model/base@model=llama31_8b acip.hub.license=llama3.1
-python -m acip.entrypoints.acip_push_to_hub model/base@model=mistral03_7b acip.hub.license=apache-2.0
-python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_3b acip.hub.license=apache-2.0
-python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_7b acip.hub.license=apache-2.0
-python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_14b acip.hub.license=apache-2.0
+python -m acip.entrypoints.acip_push_to_hub model/base@model=llama1_7b entrypoints/hub@acip=llama1_7b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=llama1_13b entrypoints/hub@acip=llama1_13b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=llama2_7b entrypoints/hub@acip=llama2_7b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=llama2_13b entrypoints/hub@acip=llama2_13b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=llama31_8b entrypoints/hub@acip=llama31_8b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=mistral03_7b entrypoints/hub@acip=mistral03_7b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_3b entrypoints/hub@acip=qwen25_3b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_7b entrypoints/hub@acip=qwen25_7b
+python -m acip.entrypoints.acip_push_to_hub model/base@model=qwen25_14b entrypoints/hub@acip=qwen25_14b

--- a/tests/model/test_pretrained.py
+++ b/tests/model/test_pretrained.py
@@ -146,15 +146,13 @@ def test_acip_model_compression(acip_model_config, temp_dir, test_device):
         acip_model_copy = ACIPModel.from_pretrained(save_path, with_init_empty_weights=True).to(test_device)
         model_compare(acip_model, acip_model_copy)
 
-        compression_ratio = 0.75
-        acip_model.prune_model_by_score(compression_ratio=compression_ratio)
-        acip_model_copy.prune_model_by_score(compression_ratio=compression_ratio)
+        size_ratio = 0.75
+        acip_model.prune_model_by_score(size_ratio=size_ratio)
+        acip_model_copy.prune_model_by_score(size_ratio=size_ratio)
         model_compare(acip_model, acip_model_copy)
 
-        print(f"Actual compression ratio: {acip_model.get_compression_ratio()}")
-        assert (
-            math.fabs(acip_model.get_compression_ratio() - compression_ratio) < 0.01
-        ), f"Compression ratio should be close to {compression_ratio}"
+        print(f"Actual size ratio: {acip_model.get_size_ratio()}")
+        assert math.fabs(acip_model.get_size_ratio() - size_ratio) < 0.01, f"Size ratio should be close to {size_ratio}"
 
         acip_model_copy.compress()
         forward_compare(acip_model, acip_model_copy, atol=1e-3)


### PR DESCRIPTION
# Description

- To avoid confusion, we consistently renamed the parameter `compression_ratio` to `size_ratio`.
`size_ratio` is closer to what the parameter actually describes, namely the ratio between the size of the compressed model and the original model (where size is measured in number of parameters).
- Improved `acip_push_to_hub` entrypoint by making rendered model cards more customizable.